### PR TITLE
Promisified the library

### DIFF
--- a/lib/pdfResult.js
+++ b/lib/pdfResult.js
@@ -66,6 +66,6 @@ method.deleteTmpFile = function() {
 	  resultObject._tmpPath = '';
 	  resultObject._invalid = true;
 	});
-}
+};
 
 module.exports = PDFResult;

--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -1,13 +1,13 @@
-"use strict"
+"use strict";
 
 var fs = require("fs"),
-	path = require("path"),
-	phantom = require("phantomjs-prebuilt"),
-	childProcess = require("child_process"),
-	tmp = require("tmp"),
-	async = require("async"),
-	debug = require('debug')('phantom-html2pdf'),
-	PDFResult = require("./pdfResult.js");
+  path = require("path"),
+  phantom = require("phantomjs-prebuilt"),
+  childProcess = require("child_process"),
+  Promise = require('bluebird'),
+  tmp = require("tmp"),
+  debug = require('debug')('phantom-html2pdf'),
+  PDFResult = require("./pdfResult.js");
 
 /* TODO: Add config for HTML2PDF class.
  * Including path to skeleton html file
@@ -15,118 +15,104 @@ var fs = require("fs"),
 
 /* Evaluates and converts input HTML, CSS and JS to PDF
  *
- * Callback format: callback(err, result)
- * If err === null, function succeeded.
+ * Returns Promise
+ *
  */
 
-function convert(options, callback) {
-	var options = options || {},
-    html = options.html || '<p>No HTML source specified!</p>',
+function convert(options) {
+  options = options || {};
+
+  var html = options.html || '<p>No HTML source specified!</p>',
     css = options.css || '',
     js = options.js || '',
     runnings = options.runnings || '',
     deleteOnAction = options.deleteOnAction || false,
     paperSize = options.paperSize || {},
-	runningsArgs = options.runningsArgs ? JSON.stringify(options.runningsArgs) : '';
+    runningsArgs = options.runningsArgs ? JSON.stringify(options.runningsArgs) : '';
 
-    /* Create temporary files for PDF, HTML, CSS and JS storage
-     * We need to wait for all of them to finish creating the files before proceeding.
+  /* Create temporary files for PDF, HTML, CSS and JS storage
+   * We need to wait for all of them to finish creating the files before proceeding.
+   */
+
+  var p1 = createTempFile('.html', html),
+    p2 = createTempFile('.pdf', ''),
+    p3 = css ? createTempFile('.css', css) : undefined,
+    p4 = js ? createTempFile('.js', js) : undefined,
+    p5 = runnings ? createTempFile('.runnings.js', runnings) : 'nofile';
+
+  return Promise.all([p1, p2, p3, p4, p5]).then(function(results) {
+
+    var paperFormat = paperSize.format || "A4",
+      paperOrientation = paperSize.orientation || "portrait",
+      paperBorder = paperSize.border || "1cm",
+      paperWidth = paperSize.width || 'false',
+      paperHeight = paperSize.height || 'false',
+      renderDelay = paperSize.delay || 500;
+
+    /* All necessary files have been created.
+     * Construct arguments and create a new phantom process.
      */
-    async.series([
-	    function(callback) {
-	    	createTempFile(".html", html, callback);
-	    },
-	    /* PDF file is necessary for further access within Node */
-	    function(callback) {
-	    	createTempFile(".pdf", "", callback);
-	    },
-	    /* Create optional CSS injection file */
-	    function(callback) {
-	    	(css) ? createTempFile(".css", css, callback) : callback(null, null);
-	    },
-	    /* Create optional JS injection file */
-	    function(callback) {
-	    	(js) ? createTempFile(".js", js, callback) : callback(null, null);
-	    },
-	    /* Create runnings (JSON header, footer) file */
-	    function(callback) {
-	      (runnings) ? createTempFile(".runnings.js", runnings, callback) : callback(null, "nofile");
-	    },
-	],
-	/* err/results-Structure
-	 * [0] = HTML temp file
-	 * [1] = PDF temp file
-	 * [2] = CSS temp file
-	 * [3] = JS temp file
-	 * [4] = Runnings temp file
-	 */
-	function(err, results) {
-	    var paperFormat = paperSize.format || "A4";
-		var paperOrientation = paperSize.orientation || "portrait";
-		var paperBorder = paperSize.border || "1cm";
-		var paperWidth  = paperSize.width || 'false';
-		var paperHeight = paperSize.height || 'false';
-		var renderDelay = paperSize.delay || 500;
+    var childArgs = [
+      path.join(__dirname, "phantom-script.js"),
+      results[0],
+      results[1],
+      results[2],
+      results[3],
+      results[4],
+      paperFormat,
+      paperOrientation,
+      paperBorder,
+      paperWidth,
+      paperHeight,
+      renderDelay,
+      runningsArgs
+    ];
 
-		/* All necessary files have been created.
-	     * Construct arguments and create a new phantom process.
-	     */
-	    var childArgs = [
-			path.join(__dirname, "phantom-script.js"),
-			results[0],
-			results[1],
-			results[2],
-			results[3],
-			results[4],
-			paperFormat,
-			paperOrientation,
-			paperBorder,
-			paperWidth,
-			paperHeight,
-			renderDelay,
-			runningsArgs
-		];
-
-		childProcess.execFile(phantom.path, childArgs, function(err, stdout, stderr) {
-			var opPointer = new PDFResult(err, results[1]);
-
-			if (typeof callback === "function") {
-				callback(err, opPointer);
-			}
-		});
-	});
+    return new Promise(function(resolve, reject) {
+      childProcess.execFile(phantom.path, childArgs, function(err) {
+        var opPointer = new PDFResult(err, results[1]);
+        return err ? reject(err) : resolve(opPointer);
+      });
+    });
+  });
 }
 
-function createTempFile(extension, contents, callback)
-{
-	var needsTempFile = false;
+function createTempFile(extension, contents) {
+  return new Promise(function(resolve, reject) {
+    var needsTempFile = false;
 
-	try {
-		if (fs.lstatSync(path.resolve(contents)).isFile()) {
-			debug('Found file "%s"', contents);
-			callback(null, path.resolve(contents));
-		} else {
-			needsTempFile = true;
-		}
-	} catch (err) {
-		needsTempFile = true;
-	}
+    try {
+      if (fs.lstatSync(path.resolve(contents)).isFile()) {
+        debug('Found file "%s"', contents);
+        resolve(path.resolve(contents));
+      } else {
+        needsTempFile = true;
+      }
+    } catch (err) {
+      needsTempFile = true;
+    }
 
-	if (needsTempFile) {
-		debug('Creating temp %s...', extension);
-		tmp.file({postfix: extension}, function (err, tmpPath, tmpFd) {
-		    if (err) { callback(err, null); }
+    if (needsTempFile) {
+      debug('Creating temp %s...', extension);
 
-		    var buffer = new Buffer(contents);
+      tmp.file({postfix: extension}, function (err, tmpPath, tmpFd) {
+        if (err) {
+          reject(err);
+        }
 
-		    fs.write(tmpFd, buffer, 0, buffer.length, null, function(err, written, buffer) {
-		    	if (err) { debug('Could not create temp file! %s', err); }
+        var buffer = new Buffer(contents);
 
-		    	fs.close(tmpFd);
-		    	callback(null, tmpPath);
-		    });
-		});
-	}
+        fs.write(tmpFd, buffer, 0, buffer.length, null, function(err) {
+          if (err) {
+            debug('Could not create temp file! %s', err);
+          }
+
+          fs.close(tmpFd);
+          resolve(tmpPath);
+        });
+      });
+    }
+  });
 }
 
 exports.convert = convert;

--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -26,7 +26,7 @@ function convert(options) {
     css = options.css || '',
     js = options.js || '',
     runnings = options.runnings || '',
-    deleteOnAction = options.deleteOnAction || false,
+    keepTmpFiles = options.keepTmpFiles === true,
     paperSize = options.paperSize || {},
     runningsArgs = options.runningsArgs ? JSON.stringify(options.runningsArgs) : '';
 
@@ -40,7 +40,7 @@ function convert(options) {
     p4 = js ? createTempFile('.js', js) : undefined,
     p5 = runnings ? createTempFile('.runnings.js', runnings) : 'nofile';
 
-  return Promise.all([p1, p2, p3, p4, p5]).then(function(results) {
+  return Promise.all([p1, p2, p3, p4, p5]).then(function (results) {
 
     var paperFormat = paperSize.format || "A4",
       paperOrientation = paperSize.orientation || "portrait",
@@ -68,51 +68,51 @@ function convert(options) {
       runningsArgs
     ];
 
-    return new Promise(function(resolve, reject) {
-      childProcess.execFile(phantom.path, childArgs, function(err) {
+    return new Promise(function (resolve, reject) {
+      childProcess.execFile(phantom.path, childArgs, function (err) {
         var opPointer = new PDFResult(err, results[1]);
         return err ? reject(err) : resolve(opPointer);
       });
     });
   });
-}
 
-function createTempFile(extension, contents) {
-  return new Promise(function(resolve, reject) {
-    var needsTempFile = false;
+  function createTempFile(extension, contents) {
+    return new Promise(function (resolve, reject) {
+      var needsTempFile = false;
 
-    try {
-      if (fs.lstatSync(path.resolve(contents)).isFile()) {
-        debug('Found file "%s"', contents);
-        resolve(path.resolve(contents));
-      } else {
+      try {
+        if (fs.lstatSync(path.resolve(contents)).isFile()) {
+          debug('Found file "%s"', contents);
+          resolve(path.resolve(contents));
+        } else {
+          needsTempFile = true;
+        }
+      } catch (err) {
         needsTempFile = true;
       }
-    } catch (err) {
-      needsTempFile = true;
-    }
 
-    if (needsTempFile) {
-      debug('Creating temp %s...', extension);
+      if (needsTempFile) {
+        debug('Creating temp %s...', extension);
 
-      tmp.file({postfix: extension}, function (err, tmpPath, tmpFd) {
-        if (err) {
-          reject(err);
-        }
-
-        var buffer = new Buffer(contents);
-
-        fs.write(tmpFd, buffer, 0, buffer.length, null, function(err) {
+        tmp.file({postfix: extension, keep: keepTmpFiles}, function (err, tmpPath, tmpFd) {
           if (err) {
-            debug('Could not create temp file! %s', err);
+            reject(err);
           }
 
-          fs.close(tmpFd);
-          resolve(tmpPath);
+          var buffer = new Buffer(contents);
+
+          fs.write(tmpFd, buffer, 0, buffer.length, null, function (err) {
+            if (err) {
+              debug('Could not create temp file! %s', err);
+            }
+
+            fs.close(tmpFd);
+            resolve(tmpPath);
+          });
         });
-      });
-    }
-  });
+      }
+    });
+  }
 }
 
 exports.convert = convert;

--- a/lib/phantom-script.js
+++ b/lib/phantom-script.js
@@ -21,8 +21,8 @@ args = cmdArgs.reduce(function (args, name, i) {
 }, {});
 
 // Fix for PhantomJS >= v2 requiring protocol specification
-var skeleton = page.libraryPath + "/skeleton.html"
-skeleton = phantom.version.major >= 2 ? "file://" + skeleton : skeleton
+var skeleton = page.libraryPath + "/skeleton.html";
+skeleton = phantom.version.major >= 2 ? "file://" + skeleton : skeleton;
 
 page.open(skeleton, function (status) {
 
@@ -86,15 +86,15 @@ page.open(skeleton, function (status) {
 function paperSize(runnings, obj) {
   // encapsulate .contents into phantom.callback()
   //   Why does phantomjs not support Array.prototype.forEach?!
-  var keys = ["header", "footer"]
+  var keys = ["header", "footer"];
   for (var i = 0; i < keys.length; i++) {
-    var which = keys[i]
+    var which = keys[i];
     if (runnings[which]
       && runnings[which].contents
       && typeof runnings[which].contents === "function") {
       obj[which] = {
         contents: phantom.callback(runnings[which].contents)
-      }
+      };
       if (runnings[which].height)
         obj[which].height = runnings[which].height
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.4.6",
     "debug": "latest",
     "phantomjs-prebuilt": "latest",
-    "tmp": "0.0.29"
+    "tmp": "latest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   ],
   "version": "3.0.0",
   "dependencies": {
+    "bluebird": "^3.4.6",
+    "debug": "latest",
     "phantomjs-prebuilt": "latest",
-    "async": "latest",
-    "tmp": "latest",
-    "debug": "latest"
+    "tmp": "0.0.29"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**This is a breaking change, as it affects the way users call the convert function**
- Promisified phantom-html2pdf.js
- Renamed previously unused `deleteOnAction` option to `keepTmpFiles` and actually utilizing it with `tmp.file()`. I renamed it, so as to avoid confusion since the `tmp.file()` option is called 'keep' and it defaults to false.
- Minor syntactic corrections (missing semicolons)
- package.json changes:
  - Added: bluebird promise library
  - Removed: async

The `convert()` function now returns a Promise:

``` javascript
var options = {
    html: '<h1>Test</h1>',
    paperSize: {format: 'Letter', orientation: 'portrait', border: '1cm'},
    runnings: 'runnings.js',
    keepTmpFiles: false,
    runningsArgs: params
};

pdf.convert(options).then(function(result) {
    /* Using a buffer and callback */
    result.toBuffer(function(returnedBuffer) {});

    /* Using a readable stream */
    var stream = result.toStream();

    /* Using the temp file path */
    var tmpPath = result.getTmpPath();

    /* Using the file writer and callback */
    result.toFile("/path/to/file.pdf", function() {});
})
.catch(function(err) {
    console.log(err);
});
```

Otherwise, everything works the same way
